### PR TITLE
Added example for more advanced performance tracking during training

### DIFF
--- a/examples/04_performance_metrics/plot_01_learning_rate_lvq.py
+++ b/examples/04_performance_metrics/plot_01_learning_rate_lvq.py
@@ -31,16 +31,27 @@ class ProcessLogger:
     def __init__(self):
         self.states = np.array([])
 
-    # A callback function has to accept two arguments, i.e., model and state, where model is the
-    # current model, and state contains a number of the optimizers variables.
+    # A callback function has to accept one argument, i.e., state, which contains a
+    # number of the optimizers variables.
     def __call__(self, state):
         self.states = np.append(self.states, state)
         return False  # The callback function can also be used to stop training early,
         # if some condition is met by returning True.
 
 
+class AdvancedProcessLogger(ProcessLogger):
+    # A more advanced callback function to extract extra information
+    def __call__(self, state):
+        global model
+        model._after_fit([], [])
+        projected_prototypes = model.transform(model.to_prototypes_view(state['variables']), scale=True)
+        dotproducts = projected_prototypes.dot(projected_prototypes.T)
+        state['dotproducts'] = dotproducts[np.triu_indices(len(dotproducts))]
+        return super().__call__(state)
+
+
 # Initiate the "logger".
-logger = ProcessLogger()
+logger = AdvancedProcessLogger()
 
 scaler = StandardScaler()
 
@@ -96,3 +107,21 @@ ax.set_title("Learning Curves (Less is better)")
 ax.plot(iteration, nfun)
 ax.plot(iteration, tfun)
 _ = ax.legend(["Cost of regular gradient update", "Cost of average gradient update"])
+
+###############################################################################
+# The dot products of pairs of (projected) prototypes are considered characteristic quantities of
+# the system of prototypes `[1]`_. These can, in addition to the cost, be used to observe
+# development of the system of prototypes over time, during training. The flattening out of these
+# curves can be used to judge settlement / stability of the system.
+
+ax.set_title("Dot products of pairs of (projected) prototypes (flatter lines show stability)")
+dpfun = np.array([state["dotproducts"] for state in logger.states]).T
+ax = plt.axes()
+ax.plot(iteration, dpfun.T)
+
+
+###############################################################################
+# References
+# ..........
+# _`[1]` M. Biehl, A. Ghosh and B. Hammer, Dynamics and generalization ability of LVQ
+# # algorithms, in Journal of Machine Learning Research 8 (Feb):323-360, 2007.


### PR DESCRIPTION
I updated the existing example for performance tracking during training with a more advanced example. For that I need access to the model (at each iteration) in the callback function. Given that you changed (some time in the past) the signature of the callback mechanism to exclude the model explicitly (note that I updated the comments to reflect that), I made a bit of a work-around using the `global model` variable. 
Furthermore, the `model.transform` function requires some attributes to be set that are normally executed by `model._after_fit(...)`.

Perhaps I'm missing some other functionality you might have in place to enable this, please let me know if this can be done with existing functionality in a nicer way.